### PR TITLE
Fix group states

### DIFF
--- a/moveit_ros/planning_interface/moveit_cpp/src/moveit_cpp.cpp
+++ b/moveit_ros/planning_interface/moveit_cpp/src/moveit_cpp.cpp
@@ -319,6 +319,7 @@ const std::shared_ptr<tf2_ros::Buffer>& MoveItCpp::getTFBuffer() const
 
 void MoveItCpp::clearContents()
 {
+  tf_listener_.reset();
   tf_buffer_.reset();
   planning_scene_monitor_.reset();
   robot_model_.reset();

--- a/moveit_ros/planning_interface/moveit_cpp/src/planning_component.cpp
+++ b/moveit_ros/planning_interface/moveit_cpp/src/planning_component.cpp
@@ -160,6 +160,7 @@ PlanningComponent::PlanSolution PlanningComponent::plan(const PlanRequestParamet
   moveit::core::RobotStatePtr start_state = considered_start_state_;
   if (!start_state)
     start_state = moveit_cpp_->getCurrentState();
+  start_state->update();
   moveit::core::robotStateToRobotStateMsg(*start_state, req.start_state);
   planning_scene->setCurrentState(*start_state);
 

--- a/moveit_ros/planning_interface/test/CMakeLists.txt
+++ b/moveit_ros/planning_interface/test/CMakeLists.txt
@@ -5,9 +5,8 @@ if (CATKIN_ENABLE_TESTING)
   add_executable(test_cleanup test_cleanup.cpp)
   target_link_libraries(test_cleanup moveit_move_group_interface)
 
-  # TODO: Fix flaky test
-  #add_rostest_gtest(moveit_cpp_test moveit_cpp_test.test moveit_cpp_test.cpp)
-  #target_link_libraries(moveit_cpp_test moveit_cpp ${catkin_LIBRARIES})
+  add_rostest_gtest(moveit_cpp_test moveit_cpp_test.test moveit_cpp_test.cpp)
+  target_link_libraries(moveit_cpp_test moveit_cpp ${catkin_LIBRARIES})
 
   add_rostest(python_move_group.test)
   add_rostest(python_move_group_ns.test)

--- a/moveit_ros/planning_interface/test/moveit_cpp_test.cpp
+++ b/moveit_ros/planning_interface/test/moveit_cpp_test.cpp
@@ -130,9 +130,6 @@ TEST_F(MoveItCppTest, TestSetStartStateToCurrentState)
 // Test setting the goal using geometry_msgs::PoseStamped and a robot's link name
 TEST_F(MoveItCppTest, TestSetGoalFromPoseStamped)
 {
-  planning_component_ptr->setStartStateToCurrentState();
-
-  geometry_msgs::PoseStamped target_pose1;
   planning_component_ptr->setGoal(target_pose1, "panda_link8");
 
   ASSERT_TRUE(static_cast<bool>(planning_component_ptr->plan()));

--- a/moveit_ros/planning_interface/test/moveit_cpp_test.test
+++ b/moveit_ros/planning_interface/test/moveit_cpp_test.test
@@ -19,7 +19,7 @@
     </include>
 
     <!-- If needed, broadcast static tf for robot root -->
-    <!--node pkg="tf2_ros" type="static_transform_publisher" name="virtual_joint_broadcaster_1" args="0 0 0 0 0 0 world panda_link0" /-->
+    <node pkg="tf2_ros" type="static_transform_publisher" name="virtual_joint_broadcaster_1" args="0 0 0 0 0 0 world panda_link0" />
 
     <!-- Send fake joint values -->
     <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">


### PR DESCRIPTION
### Description

Fix:

1- 
```
[ WARN] [1574780475.854329208]: Returning dirty link transforms
moveit_cpp_test: /root/ros_ws/src/moveit/moveit_core/robot_state/src/robot_state.cpp:1022: const Eigen::Isometry3d &moveit::core::RobotState::getFrameInfo(const std::string &, const moveit::core::LinkModel *&, bool &) const: Assertion `checkLinkTransforms()' failed.
```
2- 

```
terminate called after throwing an instance of 'boost::exception_detail::clone_impl<boost::exception_detail::error_info_injector<boost::lock_error> >'
  what():  boost: mutex lock failed in pthread_mutex_lock: Invalid argument
```
### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the MIGRATION.md notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
